### PR TITLE
Fix WP_User constructor in shibboleth_authenticate_user

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -290,7 +290,7 @@ function shibboleth_authenticate_user() {
 	}
 
 	$username = $_SERVER[$shib_headers['username']['name']];
-	$user = new WP_User($username);
+	$user = new WP_User(0, $username);
 
 	if ( $user->ID ) {
 		if ( !get_usermeta($user->ID, 'shibboleth_account') ) {


### PR DESCRIPTION
According to the WordPress documentation, the WP_User constructor takes
`User's ID, a WP_User object, or a user object from the DB.` as its first parameter.

As I understand it, that means the plugin in this revision is trying to pass a username as this parameter, which will therefore never succeed to get the appropriate user data.
source: http://developer.wordpress.org/reference/classes/wp_user/__construct/